### PR TITLE
Update macro `register_sub_command` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Option           | Description
 
 ## Sub Commands
 Sub commands can be added to the command. To define a sub command use the
-`register_subcommand` macro. You also have the option to add a description for
+`register_sub_command` macro. You also have the option to add a description for
 the auto-generated help.
 
 ```crystal
@@ -312,8 +312,8 @@ class Hello < Admiral::Command
     end
   end
 
-  register_subcommand planet, Planetary
-  register_subcommand city, Municipality
+  register_sub_command planet, Planetary
+  register_sub_command city, Municipality
 
   def run
     puts help


### PR DESCRIPTION
I'm not sure how much your syntax will be changing but I pulled this last night and found I needed to use the double underscored version of the `register_sub_command` macro to get it working.