### PR TITLE
 Added 'default_in_desc' parameter to `define_flag`

### DIFF
--- a/examples/help_example.cr
+++ b/examples/help_example.cr
@@ -1,0 +1,25 @@
+require "../src/admiral"
+
+class Help < Admiral::Command
+  define_help description: "A command that helps you", short: 'h'
+  define_flag why, default: "42..."
+  define_flag print_why : Bool, default: false, default_in_desc: false, description: "Prints why"
+
+  def run
+    unless flags.__help__
+      puts "You didn't specify '--help'"
+    end
+
+    if flags.print_why
+      print "Why?: ", flags.why, '\n'
+    end
+  end
+
+  def exit(*args); end
+end
+
+puts "help --help"
+Help.run "--help"
+
+puts "help --print-why" 
+Help.run "--print-why"

--- a/src/admiral/command/flag.cr
+++ b/src/admiral/command/flag.cr
@@ -179,7 +179,7 @@ abstract class Admiral::Command
   #
   # HelloWorld.run
   # ```
-  macro define_flag(flag, description = "", default = nil, short = nil, long = nil, required = false)
+  macro define_flag(flag, description = "", default = nil, short = nil, long = nil, required = false, default_in_desc = true)
     {% var = flag.is_a?(TypeDeclaration) ? flag.var : flag.id %}
     {% type = flag.is_a?(TypeDeclaration) ? flag.type : String %}
 
@@ -288,6 +288,6 @@ abstract class Admiral::Command
     end
 
     # Add the flag to the description constant
-    Flags::DESCRIPTIONS[{{ long + (short ? ", #{short.id}" : "") }}{% if default != nil %} + " (default: #{{{default}}})"{% elsif required == true %}+ " (required)"{% end %}] = {{ description }}
+    Flags::DESCRIPTIONS[{{ long + (short ? ", #{short.id}" : "") }}{% if (default != nil) %} + ({{default_in_desc}} ? " (default: #{{{default}}})" : "") {% elsif required == true %}+ " (required)"{% end %}] = {{ description }}
   end
 end

--- a/src/admiral/command/help.cr
+++ b/src/admiral/command/help.cr
@@ -96,7 +96,8 @@ abstract class Admiral::Command
       define_flag __help__ : Bool,
                   description: "Displays help for the current command.",
                   long: {{flag}},
-                  short: {{short}}
+                  short: {{short}},
+                  default_in_desc: false
       protected def __run__ : Nil
         if flags.__help__
           puts help


### PR DESCRIPTION
Added '`default_in_desc`' parameter to `define_flag`, that specifies whether to put the default value or not in its description. This is mainly because I think it didn't make very much sense to show to the default for, e.g. `--help`. See the example I added for usage. 

In my opinion:
```
Flags:
  --help, -h              # Displays help for the current command.
  --print-why             # Prints why
  --why (default: 42...)
``` 
Where `print-why` is defined like this: 
```
define_flag print_why : Bool, default: false, default_in_desc: false, description: "Prints why"
```
Makes much more sense than this:
```
Flags:
  --help, -h (default: false)         # Displays help for the current command.
  --print-why (default: false)         # Prints why
  --why (default: 42...)
```

However, what I am not so sure about is the name of the option '`default_in_desc`', any better name would be greatly appreciated, as I am not a native english speaker.

If you people here do not have anything against this, I can add info on this option in the readme.