### PR TITLE
feat: Verify enumerable flags have contents when required

### DIFF
--- a/spec/admiral/flag_spec.cr
+++ b/spec/admiral/flag_spec.cr
@@ -117,4 +117,16 @@ describe "flags" do
       end
     end
   end
+
+  context "enumerable flags" do
+    context "when required" do
+      it "should raise an error" do
+        File.tempfile("test") do |io|
+          EnumerableCommand.run([] of String, error: io)
+          io.rewind
+          io.gets_to_end.should eq "Flag required: --services".colorize(:red).to_s + "\n"
+        end
+      end
+    end
+  end
 end

--- a/spec/fixtures/enumerable.cr
+++ b/spec/fixtures/enumerable.cr
@@ -1,0 +1,15 @@
+require "../../src/admiral"
+
+class EnumerableCommand < Admiral::Command
+  define_flag services : Array(String),
+			short: 's',
+			long: "--services",
+      required: true
+
+  def run
+    puts flags.services
+  end
+
+  def exit(*args)
+  end
+end


### PR DESCRIPTION
Currently enumerable flags could be empty (think Array(String)) and still pass through the validation phase when `required: true` is set.

Don't know my way around macros, which is why I've added a new `kind` field to the `SPEC` structure.